### PR TITLE
Expose data-cover-customVariable

### DIFF
--- a/tasks/blanket.js
+++ b/tasks/blanket.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
       extensions: ['.js']
     });
     var blkt = require("blanket")({
+      "data-cover-customVariable": options['data-cover-customVariable'],
       "data-cover-flags": options,
       "data-cover-only": options["data-cover-only"] || options["pattern"] || "*"
     });


### PR DESCRIPTION
Expose the data-cover-customVariable parameter of blanket so that grunt-blanket may be used to instrument code to be reported in the browser via blanket.
