### PR TITLE
Update dependencies and devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+cov

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -25,18 +25,21 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "grunt test",
+    "test": "grunt test"
+  },
+  "config": {
     "blanket": {
       "data-cover-flags": {
-        "engineOnly":true
+        "engineOnly": true
       }
     }
   },
-  "dependencies":{
-    "blanket": "1.1.4"
+  "dependencies": {
+    "async": "~0.9.0",
+    "blanket": "~1.1.6"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-jshint": "~0.10.0",
     "grunt": "~0.4.0"
   },
   "peerDependencies": {

--- a/tasks/blanket.js
+++ b/tasks/blanket.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var path = require("path");
+var async = require("async");
 
 module.exports = function(grunt) {
 
@@ -32,7 +33,7 @@ module.exports = function(grunt) {
     var done = this.async();
 
     // Iterate over all specified file groups.
-    grunt.util.async.forEachSeries(this.files,function(f,n) {
+    async.eachSeries(this.files,function(f,n) {
       // Concat specified files.
       var src = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
@@ -43,7 +44,7 @@ module.exports = function(grunt) {
           return true;
         }
       });
-      grunt.util.async.forEachSeries(src,function(filepath,next) {
+      async.eachSeries(src,function(filepath,next) {
         grunt.file.recurse(filepath, function(abspath, rootdir, subdir, filename){
           if (options.extensions.indexOf(path.extname(filename)) > -1){
             // Read file source.


### PR DESCRIPTION
- `grunt.util.async` is [deprecated](http://gruntjs.com/api/grunt.util#grunt.util.async), so I replaced it with [async](https://github.com/caolan/async) module.
- I fixed JSHint setting. Now there is no need to set the "ES5" option explicitly. (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/).
- I moved Blanket configuration in `package.json` from the `scripts` field to the `config` field. (cf. alex-seville/blanket#349)
