### PR TITLE
Match against options.pattern when recursing src dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ NOTE: The src parameter MUST be a directory.  Patterns like "src/*.js" will fail
 ```js
 grunt.initConfig({
   blanket: {
-    options: {},
+    options: {
+      // pattern: "**/*interesting*.js"
+      pattern: "!src/some/dir/to/exclude/**/*"
+    },
     files: {
       'src-cov/': ['src/'],
     },

--- a/tasks/blanket.js
+++ b/tasks/blanket.js
@@ -45,7 +45,11 @@ module.exports = function(grunt) {
       });
       grunt.util.async.forEachSeries(src,function(filepath,next) {
         grunt.file.recurse(filepath, function(abspath, rootdir, subdir, filename){
-          if (options.extensions.indexOf(path.extname(filename)) > -1){
+          var matchesPattern = (options.pattern === undefined) ||
+                               (grunt.file.minimatch(abspath, options.pattern)),
+              matchesExtensions = options.extensions.indexOf(path.extname(filename)) > -1;
+
+          if (matchesPattern && matchesExtensions) {
             // Read file source.
             var inFile = grunt.file.read(abspath);
             


### PR DESCRIPTION
I couldn't get `blanket.options.pattern` to be respected and didn't see where it should be processed in the `grunt-blanket` source.

Is this the right approach to introduce it?

For context, here's my Gruntfile.js blanket section:

```javascript
    blanket: {
      options: {
        pattern: "!app/javascripts/app/react_components/**/*"
      },
      dev: {
        files: {
          "cov/app/javascripts/app": ["app/javascripts/app/"]
        }
      }
    },
```

(The instrumentation doesn't work on the JSX React components.)

Thanks!